### PR TITLE
Fix typos, warnings and tests

### DIFF
--- a/app/scripts/main-db-loader.js
+++ b/app/scripts/main-db-loader.js
@@ -130,7 +130,7 @@ const databaseHandler = {
                             break;
                         default:
                             reject(new Error('Unsupported file format.'));
-                            warning('File format not supported!');
+                            console.warn('File format not supported!');
                             break;
                     }
                 } catch (error) {
@@ -142,7 +142,7 @@ const databaseHandler = {
     
             reader.onerror = function () {
                 reject(new Error("Error reading file."));
-                warning('File format not supported!');
+                console.warn('File format not supported!');
             };
     
             reader.readAsText(file, "windows-1252");

--- a/app/scripts/plot-deltacursor.js
+++ b/app/scripts/plot-deltacursor.js
@@ -11,7 +11,7 @@ function clearAnnotationsAndShapes() {
     Plotly.relayout(plotEl, { annotations: preservedAnnotations, shapes: [] });
 }
 
-function toogleDeltaCursor() {
+function toggleDeltaCursor() {
     // Check if only "sp1" (Main Plot) is active
     const activeSubplots = getSelectedSubplots();
     if (activeSubplots.length > 1 || (activeSubplots.length === 1 && activeSubplots[0] !== "sp1")) {

--- a/app/scripts/plot.js
+++ b/app/scripts/plot.js
@@ -150,7 +150,7 @@ const plotConfiguration = {
             name: 'Delta Cursor',
             icon: Plotly.Icons.spikeline,   //https://github.com/plotly/plotly.js/blob/master/src/fonts/ploticon.js
             direction: 'up',
-            click: function(gd) {toogleDeltaCursor();}
+            click: function(gd) {toggleDeltaCursor();}
         }], //https://plotly.com/javascript/reference/layout/#layout-modebar-add
 }
 

--- a/app/tests/helper.test.js
+++ b/app/tests/helper.test.js
@@ -46,7 +46,7 @@ describe('extractRawValue', () => {
     // So the extraction index becomes substring(16 - 4 - 8, 16 - 4) = substring(4, 12).
     // The concatenated binary string from [0x34, 0x12] is:
     //   "00110100" + "00010010" = "0011010000010010"
-    // Characters 4 to 11 of that string are "01000010", which is binary for 66.
+    // Characters 4 to 11 of that string are "01000001", which is binary for 65.
     const data = [0x12, 0x34];
     const startBit = 4;
     const length = 8;

--- a/app/tests/parser-blf.test.js
+++ b/app/tests/parser-blf.test.js
@@ -157,4 +157,23 @@ describe('parseBLF', () => {
     expect(messages).toHaveLength(1);
     expect(messages[0]).toEqual(expectedMessage);
   });
+
+  test('returns empty array for invalid BLF signature', async () => {
+    const buffer = new ArrayBuffer(72);
+    const u8 = new Uint8Array(buffer);
+    // Write an invalid signature "BAD!"
+    u8[0] = 'B'.charCodeAt(0);
+    u8[1] = 'A'.charCodeAt(0);
+    u8[2] = 'D'.charCodeAt(0);
+    u8[3] = '!'.charCodeAt(0);
+
+    const fakeFile = {
+      slice: (start, end) => ({
+        arrayBuffer: async () => buffer.slice(start, end)
+      })
+    };
+
+    const messages = await parseBLF(fakeFile);
+    expect(messages).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Summary
- rename `toogleDeltaCursor` to `toggleDeltaCursor`
- replace calls to an undefined `warning()` with `console.warn()`
- fix misleading comment in helper tests
- add regression test for invalid BLF signature

## Testing
- `npm test --prefix app`

------
https://chatgpt.com/codex/tasks/task_e_683ff11c2a68832b880c7fd3c8d0d220